### PR TITLE
feat(auth): Implement issuer allow-list and required-auth flag

### DIFF
--- a/crates/client-api/src/lib.rs
+++ b/crates/client-api/src/lib.rs
@@ -30,9 +30,10 @@ pub mod util;
 pub trait NodeDelegate: Send + Sync {
     fn gather_metrics(&self) -> Vec<prometheus::proto::MetricFamily>;
     fn client_actor_index(&self) -> &ClientActorIndex;
-
+    
     type JwtAuthProviderT: auth::JwtAuthProvider;
     fn jwt_auth_provider(&self) -> &Self::JwtAuthProviderT;
+    fn auth_required(&self) -> bool;
     /// Return the leader [`Host`] of `database_id`.
     ///
     /// Returns `None` if the current leader is not hosted by this node.
@@ -363,7 +364,9 @@ impl<T: NodeDelegate + ?Sized> NodeDelegate for Arc<T> {
     fn jwt_auth_provider(&self) -> &Self::JwtAuthProviderT {
         (**self).jwt_auth_provider()
     }
-
+    fn auth_required(&self) -> bool {
+        (**self).auth_required()
+    }
     async fn leader(&self, database_id: u64) -> anyhow::Result<Option<Host>> {
         (**self).leader(database_id).await
     }

--- a/crates/testing/src/modules.rs
+++ b/crates/testing/src/modules.rs
@@ -179,9 +179,16 @@ impl CompiledModule {
 
         let certs = CertificateAuthority::in_cli_config_dir(&paths.cli_config_dir);
         let env =
-            spacetimedb_standalone::StandaloneEnv::init(config, &certs, paths.data_dir.into(), Default::default())
-                .await
-                .unwrap();
+            spacetimedb_standalone::StandaloneEnv::init(
+                config, 
+                &certs, 
+                paths.data_dir.into(), 
+                Default::default(), 
+                None, 
+                false
+            )
+            .await
+            .unwrap();
         // TODO: Fix this when we update identity generation.
         let identity = Identity::ZERO;
         let db_identity = SpacetimeAuth::alloc(&env).await.unwrap().identity;


### PR DESCRIPTION
# Description of Changes

This PR introduces critical security enhancements to the JWT authentication and authorization flow, hardening the server for production environments.

1.  **Issuer Allow-List:** A new `--allowed-oidc-issuer` CLI flag has been added. It can be specified multiple times to build a whitelist of trusted OIDC providers. The validation logic now checks the token's `iss` claim against this list before proceeding with OIDC validation. If the list is not configured, a prominent security warning is logged at startup to alert operators of the permissive default.

2.  **Required Authentication:** A new `--auth-required` CLI flag has been added to disable the on-the-fly creation of anonymous users. When this flag is enabled, any connection attempt that does not present a valid JWT will be rejected with a `401 Unauthorized` error. This is a crucial feature for private or permissioned deployments.

3.  **Authentication Flow Fix:** A logic bug in the `anon_auth_middleware` has been corrected. Previously, a request with an *invalid* token would fail validation but would then incorrectly fall back to the anonymous user creation flow. The logic has been refactored to ensure that an invalid token immediately terminates the request with a `401 Unauthorized` error, correctly distinguishing it from a request that provides no token at all.

These changes are plumbed through the application stack, from the `start` subcommand's CLI parsing, through the `StandaloneEnv` state, and into the `auth` module where the logic is enforced.

# API and ABI breaking changes

There are no external API or ABI breaking changes for clients interacting with the server. The new CLI flags are additive and the server's default behavior remains the same (though now with a security warning). Internal function signatures for `StandaloneEnv::init` and `default_auth_environment` have changed, but these are not part of the public-facing API.

# Expected complexity level and risk

**Complexity: 2/5**

The changes touch several core files (`start.rs`, `main.rs`, `auth.rs`, `token_validation.rs`), but the logic itself is straightforward. The primary complexity lies in correctly plumbing the configuration from the CLI down to the middleware where it is used.

The risk is low to moderate. The main risk is an incorrect implementation of the authentication flow, which could either improperly reject valid users or improperly accept invalid ones. However, the new logic is more explicit and robust than the previous implementation, reducing the overall risk profile of the auth system. The default behavior is unchanged, minimizing the impact on existing development workflows.

# Testing

Manual testing has been performed to validate the new functionality:

-   **[X]** Started the server with `--allowed-oidc-issuer https://accounts.google.com`. Verified that a token from a different issuer is rejected, while a connection with no token still succeeds (creates an anonymous user).
-   **[X]** Started the server with `--auth-required`. Verified that a connection attempt with no token is rejected with a `401 Unauthorized` error.
-   **[X]** Started the server with no new flags. Verified that a request with a deliberately invalid/expired token is rejected with a `401 Unauthorized` error and does *not* create an anonymous user.
-   **[X]** Verified that the security warning for a missing issuer allow-list is logged correctly at startup.

Reviewers are encouraged to sanity-check these flows, particularly the interaction between the `--auth-required` flag and the `subscribe` endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying allowed OIDC token issuers, enhancing authentication control.
  - Introduced a command-line option to require authentication and disable anonymous user creation.
- **Improvements**
  - Authentication logic now explicitly distinguishes between anonymous and invalid credentials, providing clearer error responses.
  - Added configuration options for authentication requirements in standalone environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->